### PR TITLE
remove incorrect lifetime annotation

### DIFF
--- a/src/backtrack.rs
+++ b/src/backtrack.rs
@@ -80,7 +80,7 @@ impl<'a> CalculatedViterbi<'a> {
         };
 
         let execute = |orf_inv_off: usize,
-                       iterator: Box<dyn Iterator<Item = (usize, &'a [u8])> + 'a>|
+                       iterator: Box<dyn Iterator<Item = (usize, &[u8])> + '_>|
          -> isize {
             let mut e_save = f64::MAX;
             let mut s_save = 0isize;


### PR DESCRIPTION
Hi,
rustc was previously accepting this incorrect code:
```rust
async fn test<'a>() { // `'a`, being a lifetime parameter, must be longer than the entire function body
    let f = |_: &'a str| {}; // the argument is required to outlive `'a`
    f(&String::new()); // an argument of shorter lifetime is passed!
}
```
Now that this is fixed, [we found that FGC.rs relies on this bug](https://github.com/rust-lang/rust/issues/100544). This PR tries to fix this.